### PR TITLE
Update grammar, spelling, style

### DIFF
--- a/_layouts/about_us.html
+++ b/_layouts/about_us.html
@@ -9,7 +9,7 @@ layout: default
                     <div class="hero-spotlight-header hero-spotlight-header-page">
                         <h1>About Us</h1>
                     </div>
-                    <div class="hero-spotlight-text">The Indico project started in 2002 as an European Project. In 2004, CERN adopted it as its own event management solution and financed its development till the present day. Other partners and anonymous individuals have provided valuable contributions over the years.<br>In this page, we try to mention all of them.</div>
+                    <div class="hero-spotlight-text">The Indico project started in 2002 as an European Project. In 2004, CERN adopted it as its own event-management solution and has financed its development since. Other partners and anonymous individuals have provided valuable contributions over the years.<br>In this page, we try to mention all of them.</div>
                     <h2>CURRENT TEAM</h2>
                 </div>
             </div>
@@ -83,7 +83,7 @@ layout: default
                 <div class="row">
                     <div class="col-xs-12">
                         <div class="contr-list text-center">
-                            <h2 class="contr-list-header">LONG TIME CONTRIBUTORS</h2>
+                            <h2 class="contr-list-header">LONG-TIME CONTRIBUTORS</h2>
                             <ul class="contr-list-names">
                                 <li>
                                     <span class="contr-list-names-name">Ilias Trichopoulos</span>

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -9,7 +9,7 @@ layout: default
                     <div class="hero-spotlight-header hero-spotlight-header-page">
                         <h1>Contact Us</h1>
                     </div>
-                    <div class="hero-spotlight-text">You can reach out to the Indico team with any question or request using the following email address:</div>
+                    <div class="hero-spotlight-text">You can reach out to the Indico team with any questions or requests using the following email address:</div>
                     <div class="hero-spotlight-button-lg">
                         <a href="mailto:indico-team@cern.ch">indico-team@cern.ch</a>
                     </div>

--- a/_layouts/features.html
+++ b/_layouts/features.html
@@ -7,7 +7,7 @@ layout: default
             <div class="row">
                 <div class="col-md-9 col-xm-12 block-center hero-spotlight">
                     <div class="hero-spotlight-header hero-spotlight-header-page">
-                        <h1>Organize meetings, workshops and conferences across the globe,
+                        <h1>Organise meetings, workshops and conferences across the globe,
                             bridging different collaborative tools.
                         </h1>
                     </div>
@@ -34,7 +34,7 @@ layout: default
                     </div>
                     <div class="col-md-6">
                         <h2>Events of Different Complexity</h2>
-                        <p>Lectures, meetings, workshops or conferences - Indico provides different feature sets for events with different levels of complexity. You will never need to bring with that USB flash drive ever again, or mail yourself PPT files. Your participants will be able to easily find what is going on in your organization and access presentation materials from anywhere.</p>
+                        <p>Lectures, meetings, workshops or conferences – Indico provides different feature sets for events with different levels of complexity. You will never need to bring with that USB flash drive ever again, or email yourself PPT files. Your participants will be able to easily find what is going on in your organisation and access presentation materials from anywhere.</p>
                     </div>
                 </div>
                 <div class="row feature-row">
@@ -46,7 +46,7 @@ layout: default
                     </div>
                     <div class="col-md-6 col-md-pull-6">
                         <h2>Full Coverage of the Conference Lifecycle</h2>
-                        <p>Indico will help you organize your conference from the beginning. From registration and abstract submission to the final papers, conference materials are stored within the system and made available to participants from the event web page. We've got it all covered, even participant badges!</p>
+                        <p>Indico will help you organise your conference from the beginning. From registration and abstract submission to the final papers, conference materials are stored within the system and made available to participants from the event web page. We've got it all covered, even participant badges!</p>
                     </div>
                 </div>
                 <div class="row feature-row">
@@ -66,7 +66,7 @@ layout: default
                     </div>
                     <div class="col-md-6 col-md-pull-6">
                         <h2>Hierarchical Protection Scheme</h2>
-                        <p>Indico was built with a large organization in mind (CERN). This is why events are organised using a hierarchy of categories and protection of resources can be defined at several granularity levels. From small schools to large enterprises, Indico is the intuitive solution for organised and secure event storage.</p>
+                        <p>Indico was built with a large organisation in mind (CERN). This is why events are organised using a hierarchy of categories and protection of resources can be defined at several granularity levels. From small schools to large enterprises, Indico is the intuitive solution for organised and secure event storage.</p>
                     </div>
                 </div>
                 <div class="row feature-row">
@@ -107,7 +107,7 @@ layout: default
                     </div>
                     <div class="col-md-6 col-md-pull-6">
                         <h2>Powerful REST API</h2>
-                        <p>Indico won't keep you data hostage. We believe in open collaborative platforms, and this is why we provide a simple and powerful REST API that allows for easy retrieval of information. The API is in constant expansion. You can also export your event data from your favorite scheduling/calendaring app, through iCal feeds.</p>
+                        <p>Indico won’t keep your data hostage. We believe in open collaborative platforms, and this is why we provide a simple and powerful REST API that allows for easy retrieval of information. The API is in constant expansion. You can also export your event data from your favorite scheduling/calendaring app, through iCal feeds.</p>
                     </div>
                 </div>
             </div>

--- a/_layouts/getting_started.html
+++ b/_layouts/getting_started.html
@@ -16,7 +16,7 @@ layout: default
                     <div class="getting-started-options col-md-9 col-xs-12 block-center-abs">
                         <div class="row">
                             <div class="options-description col-xs-12 block-center">
-                                Indico has a few easy ways to quickly get started, each one appealing to a different skill level and use case. Read through to see what suits your particular needs.
+                                Indico has a few easy ways to quickly get started, each one appealing to a different skill level and use-case. Read through to see what suits your particular needs.
                             </div>
                         </div>
                         <div class="row">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,8 +11,8 @@ layout: default
                 <div class="hero-spotlight-line">
                 </div>
                 <div class="hero-spotlight-header hero-spotlight-header-home">
-                    <h1>The effortless open source tool for event
-                        organization, archival and collaboration
+                    <h1>The effortless open-source tool for event
+                        organisation, archival and collaboration
                     </h1>
                 </div>
                 <div class="hero-spotlight-demo uppercase">
@@ -46,9 +46,9 @@ layout: default
                                     <img src="{{ site.baseurl }}/img/cern_logo_white.png">
                                 </div>
                                 <div class="partner-carousel-item-text">
-                                    <p>Indico is used every day at CERN to manage more than 300.000 events of different complexities and 200 meeting and conference rooms.</p>
+                                    <p>Indico is used every day at CERN to manage more than 300&nbsp;000 events of different complexities and 200 meeting and conference rooms.</p>
 
-                                    <p>CERN - “The European Organization for Nuclear Research is located at the heart of Europe, astride the Franco-Swiss border. It is known not only for its flagship project (The LHC - <em>Large Hadron Collider</em>), but as well for being the place where Sir Tim Berners-Lee created the World Wide Web in 1989.”</p>
+                                    <p>CERN - “The European Organization for Nuclear Research is located at the heart of Europe, astride the Franco-Swiss border. It is known not only for its flagship project (the Large Hadron Collider or LHC), but also for being the place where Sir Tim Berners-Lee created the World Wide Web in 1989.”</p>
                                 </div>
                             </div>
                         </div>
@@ -60,8 +60,8 @@ layout: default
                                     <h2>LHC</h2>
                                 </div>
                                 <div class="partner-carousel-item-text">
-                                    <p>Indico has been adopted by all major LHC experiments as their tool of choice for meeting organization and information sharing.</p>
-                                    <p>The Large Hadron Collider - “believed to be the most complex machine ever built by mankind, the LHC brings together thousands of physicists and engineers from all over the world with the aim of studying the Higgs boson, Supersymmetry and Dark Matter, among others.”</p>
+                                    <p>Indico has been adopted by all major LHC experiments as their tool of choice for meeting organisation and information sharing.</p>
+                                    <p>The Large Hadron Collider - “Believed to be the most complex machine ever built by humankind, the LHC brings together thousands of physicists and engineers from all over the world with the aim of studying the Higgs boson, searching for supersymmetry and for dark matter, among others.”</p>
                                 </div>
                             </div>
                         </div>
@@ -106,7 +106,7 @@ layout: default
                                         <img src="{{ site.baseurl }}/img/feature_icon_1.png">
                                     </span>
                                     <span class="features-section-feature-description col-md-8 col-xs-12">
-                                        <p>Event organization workflow that fits lectures, meetings, workshops and conferences.</p>
+                                        <p>Event-organisation workflow that fits lectures, meetings, workshops and conferences</p>
                                     </span>
                                 </div>
                                 <div class="features-section-feature col-sm-6 col-xs-12">
@@ -124,7 +124,7 @@ layout: default
                                         <img src="{{ site.baseurl }}/img/feature_icon_2.png">
                                     </span>
                                     <span class="features-section-feature-description col-md-8 col-xs-12">
-                                        <p>Easy upload and retrieval of presentations, papers and other documents.</p>
+                                        <p>Easy upload and retrieval of presentations, papers and other documents</p>
                                     </span>
                                 </div>
                                 <div class="features-section-feature col-sm-6 col-xs-12">
@@ -132,7 +132,7 @@ layout: default
                                         <img src="{{ site.baseurl }}/img/feature_icon_8.png">
                                     </span>
                                     <span class="features-section-feature-description col-md-8 col-xs-12">
-                                        <p>Permanent archival of all event material and metadata.</p>
+                                        <p>Permanent archival of all event material and metadata</p>
                                     </span>
                                 </div>
                             </div>
@@ -142,7 +142,7 @@ layout: default
                                         <img src="{{ site.baseurl }}/img/feature_icon_4.png">
                                     </span>
                                     <span class="features-section-feature-description col-md-8 col-xs-12">
-                                        <p>Conference paper reviewing functionalities.</p>
+                                        <p>Reviewing functionalities for conference papers</p>
                                     </span>
                                 </div>
                                 <div class="features-section-feature col-sm-6 col-xs-12">
@@ -150,7 +150,7 @@ layout: default
                                         <img src="{{ site.baseurl }}/img/feature_icon_6.png">
                                     </span>
                                     <span class="features-section-feature-description col-md-8 col-xs-12">
-                                        <p>Full coverage of the conference life cycle.</p>
+                                        <p>Full coverage of the conference lifecycle</p>
                                     </span>
                                 </div>
                             </div>
@@ -187,7 +187,7 @@ layout: default
                 <div class="safety-net-content-absolute">
                     <h2>Indico is Open Source software. It's free to use and easy to modify!</h2>
                     <div class="github-project">
-                        <a href="https://github.com/indico/indico">View the Github project</a>
+                        <a href="https://github.com/indico/indico">View the GitHub project</a>
                     </div>
                 </div>
             </div>

--- a/_posts/2015-10-15-indico-1-9-6-news.md
+++ b/_posts/2015-10-15-indico-1-9-6-news.md
@@ -8,10 +8,10 @@ categories: indico update release
 
 Indico was conceived as the Swiss Army Knife of event organizers. Since 2004, we have contributed to the success of
 thousands of conferences and workshops around the world. In recent years, we have expanded our feature set, never
-forgetting Indico's initial goal: to simplify basic operations in event organization and to make life easier for both
+forgetting Indico's initial goal: to simplify basic operations in event organisation and to make life easier for both
 organizers and participants.
 
-A proof of this commitment with the organization of small and larger events alike is this new release that we have
+A proof of this commitment with the organisation of small and larger events alike is this new release that we have
 prepared for our users. It targets mostly the **Registration Form** feature, which until now was a exclusive feature
 of conference events.
 

--- a/_posts/2016-03-22-indico-1-9-7-news.md
+++ b/_posts/2016-03-22-indico-1-9-7-news.md
@@ -21,7 +21,7 @@ confusion while retaining simplicity.
 
 ## Better contribution management interface
 
-Contribution management can be one of the most tedious tasks in conference organization. It often requires lots of
+Contribution management can be one of the most tedious tasks in conference organisation. It often requires lots of
 clicks and transitions between pages.
 With this new release, we've tried to simplify this process as much as possible.
 


### PR DESCRIPTION
As discussed with @pferreir, changes bring the documentation up to the standard/official CERN styles

- Use `&nbsp;` for separating "thousands"/"millions" to avoid confusion with differing European styles).
- Only CERN when referred to as "the Organization" takes a Z in its spelling; otherwise use "-ise" variant of spelling.

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>