### PR TITLE
Update footer to extend copyright date to 2019

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,7 +46,7 @@
   <div class="footer-copyright">
     <div class="container">
       <div class="row">
-        <div class="col-md-10 col-xs-12">Copyright &copy; 2014-2018 CERN. All rights reserved.</div>
+        <div class="col-md-10 col-xs-12">Copyright &copy; 2014–2019 CERN. All rights reserved.</div>
         <div class="col-md-2 col-xs-12">
           <span class="footer-icons">
             <a class="no-decoration" href="https://twitter.com/getindico"><i class="fa fa-twitter fa-lg"></i></a>


### PR DESCRIPTION
Also replaced hyphen (-) with en-dash (&ndash;) in copyright duration.

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>