### PR TITLE
Make 'Getting Started' images more mobile responsive

### DIFF
--- a/_layouts/getting_started.html
+++ b/_layouts/getting_started.html
@@ -15,7 +15,7 @@ layout: default
                 <div class="col-lg-6 col-12">
                     <a class="option-card" href="https://docs.getindico.io/en/stable/installation/">
                         <div class="row justify-content-center">
-                            <div class="col-3">
+                            <div class="col-3 xs-hidden">
                                 <img src="{{ '/img/install.png' | relative_url }}">
                             </div>
                             <div class="col-9">
@@ -28,7 +28,7 @@ layout: default
                 <div class="col-lg-6 col-12">
                     <a class="option-card" href="https://sandbox.getindico.io">
                         <div class="row justify-content-center">
-                            <div class="col-3">
+                            <div class="col-3 xs-hidden">
                                 <img src="{{ '/img/sandbox.png' | relative_url }}">
                             </div>
                             <div class="col-9">

--- a/_sass/indico.scss
+++ b/_sass/indico.scss
@@ -40,6 +40,7 @@ $blue-gradient:    linear-gradient(to right, #0054B5, #3DD8FF);
 $on-palm:          600px;
 $on-laptop:        800px;
 
+$xs:               360px;
 $sm:               576px;
 $md:               768px;
 $lg:               992px;
@@ -1128,6 +1129,30 @@ a.no-decoration {
         margin: 40px 10px;
     }
 
+    @media(max-width: $sm) {
+        .option-card {
+            img {
+                width: auto;
+                height: auto;
+            }
+
+            h4 {
+                font-size: 23px;
+            }
+        }
+    }
+
+    @media(max-width: $xs) {
+        .option-card {
+            h4 {
+                font-size: 18px;
+            }
+
+            p {
+                font-size: 15px;
+            }
+        }
+    }
  }
 
 
@@ -1479,5 +1504,11 @@ a.no-decoration {
         border-width: 0.6em 0.6em 1.8em 0.6em;
         background-color: black;
         border-radius: 18px;
+    }
+}
+
+@media (max-width: $xs) {
+    .xs-hidden {
+        display: none !important;
     }
 }


### PR DESCRIPTION
This PR fixes the poor responsiveness of images and text on smaller mobile screens. For screens that are smaller than 360px in width, the image is removed.

Before (360px):
![image](https://github.com/indico/indico.github.io/assets/7736654/623e1638-a49c-424b-8863-f716fa473084)

Before (360px+):
![image](https://github.com/indico/indico.github.io/assets/7736654/59509365-4c5a-4485-a4f4-ac67f2050ba9)

After (360px):
![image](https://github.com/indico/indico.github.io/assets/7736654/17366d7b-b1b9-4879-b428-d6e93a5b6b44)

After (360px+):
![image](https://github.com/indico/indico.github.io/assets/7736654/39bd727b-3b3b-43b8-8bca-814431e6248b)
