### PR TITLE
Update (and somewhat automate) copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,7 +46,7 @@
   <div class="footer-copyright">
     <div class="container">
       <div class="row">
-        <div class="col-md-10 col-12">Copyright &copy; 2014–2024 CERN. All rights reserved.</div>
+        <div class="col-md-10 col-12">Copyright &copy; 2014–{{ site.time | date: '%Y' }} CERN. All rights reserved.</div>
         <div class="col-md-2 col-12">
           <span class="footer-icons">
             <a class="no-decoration" href="https://fosstodon.org/@getindico" target="_blank"><i class="fa fa-mastodon fa-lg"></i></a>


### PR DESCRIPTION
This PR will automatically display the current year in the copyright footer section (via [`{{ site.time }}`](https://jekyllrb.com/docs/variables/#site-variables)).